### PR TITLE
Hoist b_factor and occupancy annotations out of per-sample loop

### DIFF
--- a/pxdesign/runner/dumper.py
+++ b/pxdesign/runner/dumper.py
@@ -136,26 +136,24 @@ class DataDumper:
         entity_poly_type=None,
     ):
         N_sample = pred_coordinates.shape[0]
+        # Set annotations once before the loop
+        atom_array.set_annotation(
+            "b_factor", np.round(np.zeros(len(atom_array)).astype(float), 2)
+        )
+        if "occupancy" not in atom_array._annot:
+            atom_array.set_annotation(
+                "occupancy", np.round(np.ones(len(atom_array)), 2)
+            )
         for sample_idx in range(N_sample):
             output_fpath = os.path.join(
                 prediction_save_dir, f"{sample_name}_sample_{sample_idx}.cif"
             )
-            # fake b_factor
-            atom_array.set_annotation(
-                "b_factor", np.round(np.zeros(len(atom_array)).astype(float), 2)
-            )
-            if "occupancy" not in atom_array._annot:
-                # fake occupancy
-                atom_array.set_annotation(
-                    "occupancy", np.round(np.ones(len(atom_array)), 2)
-                )
             save_structure_cif(
                 atom_array,
                 pred_coordinates[sample_idx],
                 output_fpath,
                 entity_poly_type,
                 sample_name,
-                # save_wounresol=False,
             )
 
     def _save_confidence(

--- a/tests/test_parallel_cif_writing.py
+++ b/tests/test_parallel_cif_writing.py
@@ -1,0 +1,17 @@
+"""Test that annotations are set once before the CIF writing loop."""
+
+from pathlib import Path
+
+
+def test_annotations_set_before_loop():
+    """Verify b_factor and occupancy are set before the per-sample loop."""
+    source = (
+        Path(__file__).parent.parent / "pxdesign" / "runner" / "dumper.py"
+    ).read_text()
+    method_start = source.find("def _save_structure")
+    method_source = source[method_start:]
+    b_factor_pos = method_source.find("b_factor")
+    loop_pos = method_source.find("for sample_idx")
+    assert b_factor_pos < loop_pos, (
+        "Annotations (b_factor, occupancy) should be set once before the per-sample loop"
+    )


### PR DESCRIPTION
## Summary
Moves the b_factor and occupancy annotation setup out of the per-sample loop in `_save_structure()`. Previously these were redundantly set on every iteration (100-500 times) despite being identical across samples.

## Changes
- `pxdesign/runner/dumper.py` — `DataDumper._save_structure()`: set annotations once before the loop

## Test plan
- [x] `pytest tests/test_parallel_cif_writing.py -v`
- [x] Run inference, verify CIF output is identical